### PR TITLE
Isaac - add recommendation controller `GET` by ID

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationController.java
@@ -42,6 +42,17 @@ public class RecommendationController extends ApiController {
         return recs;
     }
 
+    @ApiOperation(value = "Get a recommendation by ID")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public Recommendation getById(
+        @ApiParam("id") @RequestParam Long id) {
+        Recommendation recommendation = recommendationRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(Recommendation.class, id));
+        
+        return recommendation;
+    }
+
     @ApiOperation(value = "Create a new recommendation request")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping("/post")

--- a/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationControllerTests.java
@@ -55,6 +55,12 @@ public class RecommendationControllerTests extends ControllerTestCase {
                 .andExpect(status().is(403)); // logged out users can't get all
     }
 
+    @Test
+    public void logged_out_users_cannot_get_by_id() throws Exception {
+        mockMvc.perform(get("/api/recommendations?id=7"))
+                .andExpect(status().is(403)); // logged out users can't get all
+    }
+
     // Controller test for get
 
     @WithMockUser(roles = { "USER" })
@@ -99,6 +105,55 @@ public class RecommendationControllerTests extends ControllerTestCase {
 
         verify(recommendationRepository, times(1)).findAll();
         String expectedJson = mapper.writeValueAsString(expectedRecs);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+        // arrange
+
+        when(recommendationRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+        // act
+
+        MvcResult response = mockMvc.perform(get("/api/recommendations?id=7"))
+                        .andExpect(status().isNotFound()).andReturn();
+        
+        // assert
+
+        verify(recommendationRepository, times(1)).findById(eq(7L));
+        
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+
+        // arrange
+        LocalDateTime ldt = LocalDateTime.parse("2022-01-03T00:00:00");
+
+        Recommendation recommendation = Recommendation.builder()
+                        .requesterEmail("requester@mail.com")
+                        .professorEmail("professor@mail.com")
+                        .explanation("test")
+                        .dateRequested(ldt)
+                        .dateNeeded(ldt)
+                        .done(false)
+                        .build();
+
+        when(recommendationRepository.findById(eq(7L))).thenReturn(Optional.of(recommendation));
+
+        // act
+        MvcResult response = mockMvc.perform(get("/api/recommendations?id=7"))
+                        .andExpect(status().isOk()).andReturn();
+
+        // assert
+
+        verify(recommendationRepository, times(1)).findById(eq(7L));
+        String expectedJson = mapper.writeValueAsString(recommendation);
         String responseString = response.getResponse().getContentAsString();
         assertEquals(expectedJson, responseString);
     }


### PR DESCRIPTION
Closes #18 

Adds `GET` for a single record for the Recommendation Request table. Also adds related tests. Tested on localhost & on Heroku.