### PR TITLE
Isaac -- add `DELETE` function for recommendation request

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationController.java
@@ -78,4 +78,16 @@ public class RecommendationController extends ApiController {
 
         return savedRecommendation;
     }
+
+    @ApiOperation(value = "Delete a recommendation request")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteUCSBDate(
+            @ApiParam("id") @RequestParam Long id) {
+        Recommendation recommendation = recommendationRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(Recommendation.class, id));
+
+        recommendationRepository.delete(recommendation);
+        return genericMessage("Recommendation with id %s deleted".formatted(id));
+    }
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationControllerTests.java
@@ -213,10 +213,9 @@ public class RecommendationControllerTests extends ControllerTestCase {
                     .build();
 
         when(recommendationRepository.findById(eq(15L))).thenReturn(Optional.of(recommendation));
-
         // act
         MvcResult response = mockMvc.perform(
-                        delete("/api/ucsbdates?id=15")
+                        delete("/api/recommendations?id=15")
                                         .with(csrf()))
                         .andExpect(status().isOk()).andReturn();
 
@@ -226,5 +225,25 @@ public class RecommendationControllerTests extends ControllerTestCase {
 
         Map<String, Object> json = responseToJson(response);
         assertEquals("Recommendation with id 15 deleted", json.get("message"));
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_tries_to_delete_non_existant_recommendation_and_gets_right_error_message()
+                throws Exception {
+        // arrange
+
+        when(recommendationRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+        // act
+        MvcResult response = mockMvc.perform(
+                        delete("/api/recommendations?id=15")
+                                        .with(csrf()))
+                        .andExpect(status().isNotFound()).andReturn();
+
+        // assert
+        verify(recommendationRepository, times(1)).findById(15L);
+        Map<String, Object> json = responseToJson(response);
+        assertEquals("Recommendation with id 15 not found", json.get("message"));
     }
 }


### PR DESCRIPTION
Closes #16 

Adds a `DELETE` endpoint to the Recommendation controller. Also adds related tests. 
Tested on localhost & in Heroku.