### PR TITLE
Isaac - add `PUT` endpoint for Recommendation request controller

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationController.java
@@ -90,4 +90,26 @@ public class RecommendationController extends ApiController {
         recommendationRepository.delete(recommendation);
         return genericMessage("Recommendation with id %s deleted".formatted(id));
     }
+
+    @ApiOperation(value = "Update a single recommendation request")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("")
+    public Recommendation updateRecommendation(
+            @ApiParam("id") @RequestParam Long id,
+            @RequestBody @Valid Recommendation incoming) {
+
+        Recommendation recommendation = recommendationRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(Recommendation.class, id));
+
+        recommendation.setRequesterEmail(incoming.getRequesterEmail());  
+        recommendation.setProfessorEmail(incoming.getProfessorEmail());
+        recommendation.setExplanation(incoming.getExplanation());
+        recommendation.setDateRequested(incoming.getDateRequested());
+        recommendation.setDateNeeded(incoming.getDateNeeded());
+        recommendation.setDone(incoming.getDone());
+
+        recommendationRepository.save(recommendation);
+
+        return recommendation;
+    }
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationControllerTests.java
@@ -176,14 +176,14 @@ public class RecommendationControllerTests extends ControllerTestCase {
                         .explanation("test")
                         .dateRequested(ldt1)
                         .dateNeeded(ldt2)
-                        .done(false)
+                        .done(true)
                         .build();
 
         when(recommendationRepository.save(eq(recommendation))).thenReturn(recommendation);
 
         // act
         MvcResult response = mockMvc.perform(
-                        post("/api/recommendations/post?requesterEmail=requester@mail.com&professorEmail=professor@mail.com&explanation=test&dateRequested=2022-01-03T00:00:00&dateNeeded=2022-01-04T00:00:00&done=false")
+                        post("/api/recommendations/post?requesterEmail=requester@mail.com&professorEmail=professor@mail.com&explanation=test&dateRequested=2022-01-03T00:00:00&dateNeeded=2022-01-04T00:00:00&done=true")
                                         .with(csrf()))
                         .andExpect(status().isOk()).andReturn();
 


### PR DESCRIPTION
Closes #17 

Adds `PUT` (edit) endpoint for Recommendation Requests table. This adds the endpoint to RecommendationController as well as related tests to RecommendationControllerTests. Tested on localhost.

Jacoco report shows 100% test coverage.
<img width="470" alt="Screen Shot 2022-10-30 at 10 49 57 PM" src="https://user-images.githubusercontent.com/20908336/198940333-90230a25-4ff1-4645-b1a1-90e7a8a276c0.png">

Pitest mutation coverage shows 100% test strength for Recommendation controller.
<img width="912" alt="Screen Shot 2022-10-30 at 10 49 34 PM" src="https://user-images.githubusercontent.com/20908336/198940289-4bc2ed8c-bf50-476a-b6de-772f2551c7b3.png">
